### PR TITLE
Track topmost window.

### DIFF
--- a/library/src/wei/mark/standout/StandOutWindow.java
+++ b/library/src/wei/mark/standout/StandOutWindow.java
@@ -346,6 +346,9 @@ public abstract class StandOutWindow extends Service {
 	// internal state variables
 	private boolean startedForeground;
 
+	// currently topmost window
+	private int topmostWindowId = -1;
+
 	@Override
 	public IBinder onBind(Intent intent) {
 		return null;
@@ -1151,6 +1154,7 @@ public abstract class StandOutWindow extends Service {
 		}
 
 		focus(id);
+		topmostWindowId = id;
 
 		return window;
 	}
@@ -1417,6 +1421,17 @@ public abstract class StandOutWindow extends Service {
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		}
+
+		topmostWindowId = id;
+	}
+
+	/**
+	 * Retrieve the topmost window id.
+	 *
+	 * @return Window id of the topmost window.
+	 */
+	public final int getTopmostWindowId() {
+		return topmostWindowId;
 	}
 
 	/**


### PR DESCRIPTION
Hi Wei,

I am using your wonderful StandOut library for my latest project - a floating chessboard.   My chessboard basically consists of a imageview.  I track moves using the onTouch callback.

Which is a problem (in my case).

If I set the BRING_TO_FRONT_ON_TOUCH (/TAP) flags to have the library automatically bring my window to the front on touches/taps then the window will flicker everytime I move a piece on the chessboard.  It's annoying.

I then devised the following strategy ...    Do not set the BRING_TO_FRONT_ON_TOUCH (or TAP) flags on the window.
In the show() and bringToFront() methods I track which windowId have been shown or brought to the front.

In my onTouch handler I then have:

```
    if (getTopmostWindowId() != id) {
        bringToFront(id);
    }
```

... and lo and behold.  The flicker has gone!

I hope you find the patch worthwhile for inclusion into the StandOut library - or, better yet, let it serve for a better implementation if possible :-)

Anyway - thanks for a nice library.   I expect tor release my chessboard app one of the days .... - and it wouldn't have been possible without your library!

Best regards,
Brian
