### PR TITLE
Fix crash when the view was not removed from the window manager in time.

### DIFF
--- a/library/src/wei/mark/standout/StandOutWindow.java
+++ b/library/src/wei/mark/standout/StandOutWindow.java
@@ -1098,6 +1098,12 @@ public abstract class StandOutWindow extends Service {
 		StandOutLayoutParams params = window.getLayoutParams();
 
 		try {
+			// force remove the view from the window manager to prevent adding it again
+			mWindowManager.removeView(window);
+		} catch(IllegalArgumentException ex) {
+		}
+
+		try {
 			// add the view to the window manager
 			mWindowManager.addView(window, params);
 


### PR DESCRIPTION
Running applications that use StandOutWindow again without closing them before results in a crash. For `StandOut/example` the window disappears and the _Service_ prints out the following exception:

```
10-03 09:37:16.885  30030-30030/wei.mark.example W/System.err﹕ java.lang.IllegalStateException: View wei.mark.standout.ui.Window{421d2e98 V.E..... ......ID 0,0-250,300} has already been added to the window manager.
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:230)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:69)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at wei.mark.standout.StandOutWindow.show(StandOutWindow.java:1102)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at wei.mark.standout.StandOutWindow.onStartCommand(StandOutWindow.java:381)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2719)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at android.app.ActivityThread.access$2100(ActivityThread.java:144)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1302)
10-03 09:37:16.895  30030-30030/wei.mark.example W/System.err﹕ at android.os.Handler.dispatchMessage(Handler.java:102)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at android.os.Looper.loop(Looper.java:136)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at android.app.ActivityThread.main(ActivityThread.java:5139)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at java.lang.reflect.Method.invokeNative(Native Method)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at java.lang.reflect.Method.invoke(Method.java:515)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:796)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:612)
10-03 09:37:16.905  30030-30030/wei.mark.example W/System.err﹕ at dalvik.system.NativeStart.main(Native Method)
```

The problematic line in `StandOutWindow.java` is:

``` java
            // add the view to the window manager
            mWindowManager.addView(window, params);
```

Although the code in _Activity_ looks like:

``` java
        StandOutWindow.closeAll(this, WidgetsWindow.class);
        StandOutWindow.show(this, SimpleWindow.class, StandOutWindow.DEFAULT_ID);
```

The problem originates in the fact that the close/hide animation take some time to finish and it doesn't remove the window from the window manager immediately.

The included patch resolves this by forceful removing of the view from the window manager before adding it again.
