### PR TITLE
Removed problematic already shown and hidden exceptions.

### DIFF
--- a/library/src/wei/mark/standout/StandOutWindow.java
+++ b/library/src/wei/mark/standout/StandOutWindow.java
@@ -1078,15 +1078,17 @@ public abstract class StandOutWindow extends Service {
 			window = new Window(this, id);
 		}
 
-		if (window.visibility == Window.VISIBILITY_VISIBLE) {
-			throw new IllegalStateException("Tried to show(" + id
-					+ ") a window that is already shown.");
-		}
-
 		// alert callbacks and cancel if instructed
 		if (onShow(id, window)) {
 			Log.d(TAG, "Window " + id + " show cancelled by implementation.");
 			return null;
+		}
+
+		// focus an already shown window
+		if (window.visibility == Window.VISIBILITY_VISIBLE) {
+			Log.d(TAG, "Window " + id + " is already shown.");
+			focus(id);
+			return window;
 		}
 
 		window.visibility = Window.VISIBILITY_VISIBLE;
@@ -1164,15 +1166,15 @@ public abstract class StandOutWindow extends Service {
 					+ ") a null window.");
 		}
 
-		if (window.visibility == Window.VISIBILITY_GONE) {
-			throw new IllegalStateException("Tried to hide(" + id
-					+ ") a window that is not shown.");
-		}
-
 		// alert callbacks and cancel if instructed
 		if (onHide(id, window)) {
-			Log.w(TAG, "Window " + id + " hide cancelled by implementation.");
+			Log.d(TAG, "Window " + id + " hide cancelled by implementation.");
 			return;
+		}
+
+		// ignore if window is already hidden
+		if (window.visibility == Window.VISIBILITY_GONE) {
+			Log.d(TAG, "Window " + id + " is already hidden.");
 		}
 
 		// check if hide enabled


### PR DESCRIPTION
When calling show and hide intents from another thread a race condition may appear causing multiple calls to window show and hide functions. It is unnecessary for those functions throw an exception, because it is obvious what should be achieved (window either shown or hidden).

The proposed patch replaces the exceptions with a debugging notice and "does the right thing".
